### PR TITLE
resman_destroy null pointer fix

### DIFF
--- a/src/resman.c
+++ b/src/resman.c
@@ -140,6 +140,8 @@ void resman_destroy(struct resman *rman)
 	if(!rman) return;
 
 	for(i=0; i<dynarr_size(rman->res); i++) {
+		if(!rman->res[i]) continue;
+
 		if(rman->destroy_func) {
 			rman->destroy_func(i, rman->destroy_func_cls);
 		}


### PR DESCRIPTION
`resman_destroy` failed to check for null entries in the resources array which would happen as a result of destroying a resource.